### PR TITLE
Clarify MicroProfile server in test comment

### DIFF
--- a/src/test/java/com/example/SimpleWebServerTest.java
+++ b/src/test/java/com/example/SimpleWebServerTest.java
@@ -15,8 +15,8 @@ import java.time.Duration;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Integration tests for {@link SimpleWebServer} verifying greeting and health
- * endpoints.
+ * Integration tests for the MicroProfile server launched via {@code ApplicationConfig},
+ * verifying the greeting and health endpoints.
  */
 public class SimpleWebServerTest {
   // WebServer instance started once for all tests


### PR DESCRIPTION
## Summary
- Update `SimpleWebServerTest` class comment to explain that the tests exercise the MicroProfile server launched via `ApplicationConfig`.

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a3fe95baf8832f80f02946a8d86801